### PR TITLE
Fix project linting errors

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import App from './App'
-import { useTrainingStore } from '@/stores/trainingStore'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useTrainingInit } from '@/hooks/useTrainingInit'
+import { useTrainingStore } from '@/stores/trainingStore'
+import App from './App'
 
 // Mock the training store
 vi.mock('@/stores/trainingStore', () => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
-import { ThemeToggle } from '@/components/ThemeToggle'
-import { useTrainingStore } from '@/stores/trainingStore'
-import { useTrainingInit } from '@/hooks/useTrainingInit'
+import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { ModuleCard } from '@/components/ModuleCard'
 import { ModuleViewer } from '@/components/ModuleViewer'
-import { ConfirmDialog } from '@/components/ConfirmDialog'
+import { ThemeToggle } from '@/components/ThemeToggle'
 import { Button } from '@/components/ui/button'
+import { useTrainingInit } from '@/hooks/useTrainingInit'
+import { useTrainingStore } from '@/stores/trainingStore'
 
 function App() {
   const { modules, completedCount, totalCount, overallProgress, clearAllData } = useTrainingStore()

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ConfirmDialog } from './ConfirmDialog'
 
 describe('ConfirmDialog', () => {

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -45,10 +45,19 @@ export const ConfirmDialog = ({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Overlay */}
-      <div 
+      <div
         className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+        role="button"
+        tabIndex={0}
         onClick={onCancel}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onCancel()
+          }
+        }}
         data-testid="dialog-overlay"
+        aria-label="Close dialog"
       />
       
       {/* Dialog */}

--- a/src/components/ModuleCard.test.tsx
+++ b/src/components/ModuleCard.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { ModuleCard } from './ModuleCard'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useTrainingStore } from '@/stores/trainingStore'
+import { ModuleCard } from './ModuleCard'
 
 // Mock the training store
 vi.mock('@/stores/trainingStore', () => ({

--- a/src/components/ModuleCard.tsx
+++ b/src/components/ModuleCard.tsx
@@ -1,6 +1,6 @@
+import { FaShieldAlt, FaBookOpen, FaChartBar, FaUsers, FaCloud, FaExclamationTriangle, FaFileAlt, FaEye, FaUserTie } from 'react-icons/fa'
 import { Button } from '@/components/ui/button'
 import { useTrainingStore } from '@/stores/trainingStore'
-import { FaShieldAlt, FaBookOpen, FaChartBar, FaUsers, FaCloud, FaExclamationTriangle, FaFileAlt, FaEye, FaUserTie } from 'react-icons/fa'
 
 interface ModuleCardProps {
   moduleId: number

--- a/src/components/ModuleViewer.tsx
+++ b/src/components/ModuleViewer.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/button'
-import { useTrainingStore } from '@/stores/trainingStore'
 import { FaArrowLeft, FaArrowRight, FaCheck, FaTimes, FaLightbulb, FaQuestionCircle, FaBookOpen, FaClock, FaGraduationCap, FaUserShield } from 'react-icons/fa'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import { Button } from '@/components/ui/button'
+import { useTrainingStore } from '@/stores/trainingStore'
 
 interface ModuleViewerProps {
   moduleId: number
@@ -108,16 +108,6 @@ export const ModuleViewer = ({ moduleId, onBack }: ModuleViewerProps) => {
       conclusion: FaCheck,
     }
     return iconMap[type as keyof typeof iconMap] || FaBookOpen
-  }
-
-  const formatContent = (content: string) => {
-    // Split content into paragraphs and add some formatting
-    const paragraphs = content.split('\n\n')
-    return paragraphs.map((paragraph, index) => (
-      <p key={index} className="mb-4 text-gray-700 dark:text-gray-300 leading-relaxed">
-        {paragraph}
-      </p>
-    ))
   }
 
   if (showQuiz && !quizSubmitted) {

--- a/src/hooks/useTrainingInit.test.ts
+++ b/src/hooks/useTrainingInit.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
-import { useTrainingInit } from './useTrainingInit'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useTrainingStore } from '@/stores/trainingStore'
+import { useTrainingInit } from './useTrainingInit'
 
 // Mock the training store
 vi.mock('@/stores/trainingStore', () => ({

--- a/src/stores/trainingStore.test.ts
+++ b/src/stores/trainingStore.test.ts
@@ -1,6 +1,6 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useTrainingStore } from './trainingStore'
-import { act, renderHook, waitFor } from '@testing-library/react'
 
 // Mock localStorage
 const mockLocalStorage = {

--- a/src/stores/trainingStore.ts
+++ b/src/stores/trainingStore.ts
@@ -128,6 +128,7 @@ export const useTrainingStore = create<TrainingState>()(
             }
           })
         } catch (error) {
+          // eslint-disable-next-line no-console
           console.error('Failed to load modules:', error)
           set({ initialized: true })
         }
@@ -275,6 +276,7 @@ export const useTrainingStore = create<TrainingState>()(
             initialized: true
           })
         } catch (error) {
+          // eslint-disable-next-line no-console
           console.error('Failed to reload modules:', error)
           set({
             modules: [],
@@ -314,7 +316,7 @@ if (import.meta.hot) {
   // Helper to register an HMR accept handler for a single JSON file
   const acceptUpdate = (path: string, moduleId: number) => {
     // Vite will re-import the updated JSON and pass it to the callback
-    import.meta.hot!.accept(path, (mod: any) => {
+    import.meta.hot.accept(path, (mod: { default?: Partial<TrainingModule> }) => {
       if (!mod?.default) return
       // Merge the fresh JSON content into the existing module while
       // preserving runtime fields like progress, completed, etc.


### PR DESCRIPTION
Fix all linting errors to ensure code quality and maintainability.

This PR addresses all identified linting warnings and errors, including:
*   Updating `ConfirmDialog.tsx` overlay for full keyboard accessibility (resolves `jsx-a11y` warnings).
*   Removing the unused `formatContent` helper from `ModuleViewer.tsx`.
*   Adding `eslint-disable-next-line` comments for intentional `console.error` calls in `trainingStore.ts`.
*   Reworking the HMR handler in `trainingStore.ts` to drop non-null assertions and add type parameters.
*   Reordering imports in several files to comply with linting rules.